### PR TITLE
Update UnitTest1.cs

### DIFF
--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -15,6 +15,7 @@ public class MyTest : PageTest
 		Page.Response += Listener;
 		await Page.GotoAsync("https://example.com");
 		Console.WriteLine($"Expected: 1 - Actual: {amountOfResponses}");
+  		Page.Response -= Listener; // unsubscribe or you are still active on the first listener when you are trying to fire the 2nd Listener
 	}
 
 	[Test]
@@ -23,6 +24,7 @@ public class MyTest : PageTest
 		Page.Response += Listener;
 		await Page.GotoAsync("https://example.com");
 		Console.WriteLine($"Expected: 2 - Actual: {amountOfResponses}");
+  		Page.Response -= Listener; 
         Console.WriteLine("Why is the 2nd Listener() call not printed to the Console?");
 	}
 


### PR DESCRIPTION
Every time you run a test, you add another Listener to the Page.Response event, but you never unsubscribe. As a result, by the time TC2 runs, it might not be printing the second Listener() call because the subscription from TC1 is still active, causing interference.